### PR TITLE
Oci 5.1.0 nginx private ingress

### DIFF
--- a/kubernetes/ansible/roles/helm-deploy/tasks/main.yml
+++ b/kubernetes/ansible/roles/helm-deploy/tasks/main.yml
@@ -120,6 +120,12 @@
 - name: Get deployed image name - deployments
   shell: kubectl get deployments.apps {{ release_name }} -o json -n {{ namespace }} | jq -r '.spec.template.spec.containers[0].image | split("/")[1]'
   register: image
+  when: cloud_service_provider != "oci"
+
+- name: Get deployed image name - deployments for OCI
+  shell: kubectl get deployments.apps {{ release_name }} -o json -n {{ namespace }} | jq -r '.spec.template.spec.containers[0].image | split("/")[3]'
+  register: image
+  when: cloud_service_provider == "oci"
 
 - set_fact:
    deployed_image: "{{ image }}"

--- a/kubernetes/helm_charts/core/nginx-private-ingress/templates/configmap.yaml
+++ b/kubernetes/helm_charts/core/nginx-private-ingress/templates/configmap.yaml
@@ -39,8 +39,9 @@ data:
       server {
         listen 80;
         listen [::]:80;
-        server_name {{ .Values.nginx_private_ingress_ip }};
-
+{{- if and .Values.nginx_private_ingress_ip (ne .Values.csp "oci") }}
+        server_name: {{ .Values.nginx_private_ingress_ip }};
+{{- end }}
         resolver {{ .Values.kube_dns_ip }};
 
         location /learner/ {
@@ -125,7 +126,9 @@ data:
           set $target http://report-service.{{ .Values.namespace }}.svc.cluster.local:3030;
           rewrite ^/report/(.*) /$1 break;
           proxy_http_version 1.1;
+{{- if and .Values.nginx_private_ingress_ip (ne .Values.csp "oci") }}
           proxy_set_header Host $server_name;
+{{- end }}
           proxy_pass $target;
         }
         location /search/ {
@@ -244,7 +247,9 @@ data:
           set $target http://registry-service.{{ .Values.namespace }}.svc.cluster.local:8081;
           rewrite ^/registry-service/(.*) /$1 break;
           proxy_http_version 1.1;
+{{- if and .Values.nginx_private_ingress_ip (ne .Values.csp "oci") }}
           proxy_set_header Host $server_name;
+{{- end }}
           proxy_pass $target;
         }
         location /ml-projects/ {

--- a/kubernetes/helm_charts/core/nginx-private-ingress/values.j2
+++ b/kubernetes/helm_charts/core/nginx-private-ingress/values.j2
@@ -38,3 +38,4 @@ autoscaling:
   targetCPUUtilizationPercentage: {{ nginx_private_ingress_autoscaling_targetCPUUtilizationPercentage|default(60) }}
   targetMemoryUtilizationPercentage: {{ nginx_private_ingress_autoscaling_targetMemoryUtilizationPercentage|default('') }}
 
+csp: {{cloud_service_provider}}


### PR DESCRIPTION
Added csp switch in the helm chart for private nginx . 
This is because oci cant provide an ip in advance if we are creating a private lb

https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengcreatingloadbalancer.htm#Creating2

`You cannot add the loadBalancerIP property to the manifest file for an internal load balancer service (that is, a manifest file that includes the service.beta.kubernetes.io/oci-load-balancer-internal: "true" or oci-network-load-balancer.oraclecloud.com/internal: "true" annotation).`

This prevents the nginx pod getting started because in the configmap nginx-private-ingress.conf  its defined like

```
      server {
        listen 80;
        listen [::]:80;
        server_name: {{ .Values.nginx_private_ingress_ip }};
```

if server_name is null the pod doesnt start.

other change is to add the csp switch in validating the image tag. 