### PR TITLE
Added role to install oci cli as part of bootstrap

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -48,7 +48,17 @@
   roles:
     - role: aws-cli
   tags:
-    - aws_cli    
+    - aws_cli   
+
+- hosts: "{{ hosts }}"
+  become: yes
+  ignore_unreachable: yes
+  vars_files:
+    - "{{inventory_dir}}/secrets.yml"
+  roles:
+    - role: oci-cli
+  tags:
+    - oci_cli   
 
 - hosts: "{{ hosts| default('all') }}"
   become: yes

--- a/ansible/roles/oci-cli/defaults/main.yml
+++ b/ansible/roles/oci-cli/defaults/main.yml
@@ -1,0 +1,1 @@
+oci_cli_url: https://github.com/oracle/oci-cli/releases/download/v3.22.0/oci-cli-3.22.0-Ubuntu-18.04-Offline.zip

--- a/ansible/roles/oci-cli/tasks/main.yml
+++ b/ansible/roles/oci-cli/tasks/main.yml
@@ -18,10 +18,7 @@
     dest: /tmp/
     remote_src: yes    
 
-- name: debug through ansible.env
-  debug: var=ansible_env.HOME
-
 - name: install oci cli
-  shell: ./oci-cli-installation/install.sh --install-dir {{ lookup('env', 'HOME') }} --exec-dir {{ lookup('env', 'HOME') }} --script-dir {{ lookup('env', 'HOME') }} --accept-all-defaults
+  shell: ./oci-cli-installation/install.sh --install-dir {{ ansible_env.HOME }} --exec-dir {{ ansible_env.HOME }} --script-dir {{ ansible_env.HOME }} --accept-all-defaults
   args:
     chdir: /tmp/

--- a/ansible/roles/oci-cli/tasks/main.yml
+++ b/ansible/roles/oci-cli/tasks/main.yml
@@ -18,6 +18,9 @@
     dest: /tmp/
     remote_src: yes    
 
+- name: debug through ansible.env
+  debug: var=ansible_env.HOME
+
 - name: install oci cli
   shell: ./oci-cli-installation/install.sh --install-dir {{ lookup('env', 'HOME') }} --exec-dir {{ lookup('env', 'HOME') }} --script-dir {{ lookup('env', 'HOME') }} --accept-all-defaults
   args:

--- a/ansible/roles/oci-cli/tasks/main.yml
+++ b/ansible/roles/oci-cli/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Download the installation file
+  get_url:
+    url: "{{ oci_cli_url }}"
+    dest: /tmp/ocicli.zip
+
+- name: Installing unzip
+  apt:
+    name: "{{item}}"
+    state: latest
+  with_items:
+    - zip
+    - unzip
+
+- name: Unzip the installer
+  unarchive:
+    src: /tmp/ocicli.zip
+    dest: /tmp/
+    remote_src: yes    
+
+- name: install oci cli
+  shell: ./oci-cli-installation/install.sh --install-dir {{ lookup('env', 'HOME') }} --exec-dir {{ lookup('env', 'HOME') }} --script-dir {{ lookup('env', 'HOME') }} --accept-all-defaults
+  args:
+    chdir: /tmp/


### PR DESCRIPTION
Added the role to install oci cli as part of bootstrap

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Install oci-cli as part of bootstrap run

- [X] Executed OpsAdministration/Core/Bootstrap to run oci_cli tag

