### PR TITLE
Update proxy-default.conf

### DIFF
--- a/ansible/roles/stack-proxy/templates/proxy-default.conf
+++ b/ansible/roles/stack-proxy/templates/proxy-default.conf
@@ -47,7 +47,7 @@ server {
   # Limitting open connection per ip
   limit_conn limitbyaddr {{ nginx_per_ip_connection_limit }};
   proxy_set_header    Host              $host;
-  proxy_set_header    X-Real-IP         $remote_addr;
+  proxy_set_header    X-Real-IP         $http_x_client_ip;
   proxy_set_header    X-Forwarded-SSL   on;
   proxy_set_header    X-Forwarded-Proto $scheme;
 
@@ -79,7 +79,7 @@ server {
     proxy_pass $target;
     
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Real-IP $http_x_client_ip;
     proxy_set_header X-Scheme $scheme;
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
@@ -96,7 +96,7 @@ server {
     proxy_pass $target;
 
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Real-IP $http_x_client_ip;
     proxy_set_header X-Scheme $scheme;
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
@@ -107,7 +107,7 @@ server {
     proxy_pass $target;
 
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Real-IP $http_x_client_ip;
     proxy_set_header X-Scheme $scheme;
     proxy_connect_timeout 1;
     proxy_send_timeout 30;
@@ -127,9 +127,9 @@ server {
       client_max_body_size 60M;
       proxy_set_header Connection "";
       proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Real-IP $http_x_client_ip;
       proxy_set_header X-Scheme $scheme;
-      proxy_set_header    X-Forwarded-For   $remote_addr;
+      proxy_set_header    X-Forwarded-For   $http_x_client_ip;
       proxy_connect_timeout 5;
       proxy_send_timeout 60;
       proxy_read_timeout 70;
@@ -157,9 +157,9 @@ server {
     rewrite ^/api/(.*) /$1 break;
     proxy_set_header Connection "";
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Real-IP $http_x_client_ip;
     proxy_set_header X-Scheme $scheme;
-    proxy_set_header    X-Forwarded-For   $remote_addr;
+    proxy_set_header    X-Forwarded-For   $http_x_client_ip;
     proxy_connect_timeout 5;
     proxy_send_timeout 60;
     proxy_read_timeout 70;
@@ -177,7 +177,7 @@ server {
     set $target http://{{swarm_dashboard}}:4111;
     proxy_pass $target;
     proxy_set_header Host                    $host;
-    proxy_set_header X-Real-IP               $remote_addr;
+    proxy_set_header X-Real-IP               $http_x_client_ip;
     proxy_set_header X-Scheme                $scheme;
     proxy_set_header X-Auth-Request-Redirect $request_uri;
   }
@@ -186,7 +186,7 @@ server {
     set $target http://{{swarm_dashboard}}:4111;
     proxy_pass $target;
     proxy_set_header Host             $host;
-    proxy_set_header X-Real-IP        $remote_addr;
+    proxy_set_header X-Real-IP        $http_x_client_ip;
     proxy_set_header X-Scheme         $scheme;
     # nginx auth_request includes headers but not body
     proxy_set_header Content-Length   "";
@@ -232,7 +232,7 @@ server {
     proxy_pass $target;
 
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Real-IP $http_x_client_ip;
     proxy_set_header X-Scheme $scheme;
     proxy_connect_timeout 1;
     proxy_send_timeout 30;
@@ -255,7 +255,7 @@ server {
     proxy_pass $target;
 
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Real-IP $http_x_client_ip;
     proxy_set_header X-Scheme $scheme;
     proxy_connect_timeout 1;
     proxy_send_timeout 30;
@@ -271,7 +271,7 @@ server {
     proxy_pass $target;
 
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Real-IP $http_x_client_ip;
     proxy_set_header X-Scheme $scheme;
     proxy_connect_timeout 1;
     proxy_send_timeout 30;
@@ -412,7 +412,7 @@ location ~* ^/content-plugins/(.*) {
     rewrite ^/(.*) /$1 break;
 
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Real-IP $http_x_client_ip;
     proxy_set_header X-Scheme $scheme;
     proxy_connect_timeout 5;
     proxy_send_timeout 60;
@@ -467,7 +467,7 @@ location ~* ^/desktop/(.*) {
     rewrite ^/(.*) /$1 break;
 
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Real-IP $http_x_client_ip;
     proxy_set_header X-Scheme $scheme;
     proxy_connect_timeout 5;
     proxy_send_timeout 60;
@@ -484,7 +484,7 @@ location ~* ^/desktop/(.*) {
     rewrite ^/v3/device/register/(.*) /v3/device/register/$1 break;
 
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Real-IP $http_x_client_ip;
     proxy_set_header X-Scheme $scheme;
     proxy_connect_timeout 5;
     proxy_send_timeout 60;
@@ -499,7 +499,7 @@ location ~* ^/desktop/(.*) {
 
     proxy_http_version 1.1;
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Real-IP $http_x_client_ip;
     proxy_set_header X-Scheme $scheme;
     proxy_connect_timeout 5;
     proxy_send_timeout 60;
@@ -513,7 +513,7 @@ location ~* ^/desktop/(.*) {
       proxy_cache_valid 200 3600s;
 
       proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Real-IP $http_x_client_ip;
       proxy_set_header X-Scheme $scheme;
       proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
@@ -530,9 +530,9 @@ location ~* ^/desktop/(.*) {
       client_max_body_size 60M;
       proxy_set_header Connection "";
       proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Real-IP $http_x_client_ip;
       proxy_set_header X-Scheme $scheme;
-      proxy_set_header    X-Forwarded-For   $remote_addr;
+      proxy_set_header    X-Forwarded-For   $http_x_client_ip;
       proxy_connect_timeout 5;
       proxy_send_timeout 60;
       proxy_read_timeout 70;


### PR DESCRIPTION
when use with WAF, WAF will add http_x_client_ip header which is the actual client ip address

This is a placeholder for the required change. please note the re-deploy of nginx public will change IP. do NOT deploy until it is ready