### PR TITLE
updated kafka setup zookeeper

### DIFF
--- a/ansible/roles/setup-kafka/defaults/main.yml
+++ b/ansible/roles/setup-kafka/defaults/main.yml
@@ -3,7 +3,7 @@ env: dev
 ml_kafka_topic_create: false
 uci_kafka_topic_create: false
 av_kafka_topic_create: false
-
+zookeeper_host: "{{ groups['zookeeper'][0] | default('localhost')}}"
 processing_kafka_overriden_topics:
   - name: lms.audit.events
     retention_time: 172800000

--- a/ansible/roles/setup-kafka/tasks/main.yml
+++ b/ansible/roles/setup-kafka/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: create topics
-  command: /opt/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --create --topic {{env_name}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{zookeeper_host}}:2181 --create --topic {{env_name}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
   with_items: "{{processing_kafka_topics}}"
   ignore_errors: true
   when: kafka_id=="1"
@@ -7,14 +7,14 @@
     - processing-kafka
 
 - name: override retention time
-  command: /opt/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --alter --topic {{env_name}}.{{item.name}} --config retention.ms={{ item.retention_time }}
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{zookeeper_host}}:2181 --alter --topic {{env_name}}.{{item.name}} --config retention.ms={{ item.retention_time }}
   with_items: "{{processing_kafka_overriden_topics}}"
   when: kafka_id=="1" and item.retention_time is defined  
   tags:
     - processing-kafka
 
 - name: create topics
-  command: /opt/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --create --topic {{env_name}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{zookeeper_host}}:2181 --create --topic {{env_name}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
   with_items: "{{ml_service_topics}}"
   ignore_errors: true
   when: kafka_id=="1" and ml_kafka_topic_create
@@ -22,7 +22,7 @@
     - processing-kafka
 
 - name: create topics
-  command: /opt/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --create --topic {{env_name}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{zookeeper_host}}:2181 --create --topic {{env_name}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
   with_items: "{{uci_service_topics}}"
   ignore_errors: true
   when: kafka_id=="1" and uci_kafka_topic_create
@@ -30,7 +30,7 @@
     - processing-kafka
     
 - name: create topics
-  command: /opt/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --create --topic {{env_name}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
+  command: /opt/kafka/bin/kafka-topics.sh --zookeeper {{zookeeper_host}}:2181 --create --topic {{env_name}}.{{item.name}} --partitions {{ item.num_of_partitions }} --replication-factor {{ item.replication_factor }}
   with_items: "{{av_service_topics}}"
   ignore_errors: true
   when: kafka_id=="1" and av_kafka_topic_create


### PR DESCRIPTION
This change is done, so that kafka command uses zookeeper ip from the ansible host file, instead of localhost.
Localhost works fine, if its a basic setup of sunbird, but if there is a dedicated zookeeper host then local host will not work.

