### PR TITLE
Update psp.yaml

### DIFF
--- a/kubernetes/helm_charts/monitoring/prometheus-operator/templates/prometheus/psp.yaml
+++ b/kubernetes/helm_charts/monitoring/prometheus-operator/templates/prometheus/psp.yaml
@@ -1,56 +1,56 @@
-{{- if and .Values.prometheus.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: {{ template "prometheus-operator.fullname" . }}-prometheus
-  namespace: {{ $.Release.Namespace }}
-  labels:
-    app: {{ template "prometheus-operator.name" . }}-prometheus
-{{- if .Values.global.rbac.pspAnnotations }}
-  annotations:
-{{ toYaml .Values.global.rbac.pspAnnotations | indent 4 }}
-{{- end }}
-{{ include "prometheus-operator.labels" . | indent 4 }}
-spec:
-  privileged: false
-  # Required to prevent escalations to root.
-  # allowPrivilegeEscalation: false
-  # This is redundant with non-root + disallow privilege escalation,
-  # but we can provide it for defense in depth.
-  #requiredDropCapabilities:
-  #  - ALL
-  # Allow core volume types.
-  volumes:
-    - 'configMap'
-    - 'emptyDir'
-    - 'projected'
-    - 'secret'
-    - 'downwardAPI'
-    - 'persistentVolumeClaim'
-  hostNetwork: false
-  hostIPC: false
-  hostPID: false
-  runAsUser:
-    # Permits the container to run with root privileges as well.
-    rule: 'RunAsAny'
-  seLinux:
-    # This policy assumes the nodes are using AppArmor rather than SELinux.
-    rule: 'RunAsAny'
-  supplementalGroups:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 0
-        max: 65535
-  fsGroup:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 0
-        max: 65535
-  readOnlyRootFilesystem: false
-{{- if .Values.prometheus.podSecurityPolicy.allowedCapabilities }}
-  allowedCapabilities:
-{{ toYaml .Values.prometheus.podSecurityPolicy.allowedCapabilities | indent 4 }}
-{{- end }}
-{{- end }}
+#{{- if and .Values.prometheus.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
+#apiVersion: policy/v1beta1
+#kind: PodSecurityPolicy
+#metadata:
+#  name: {{ template "prometheus-operator.fullname" . }}-prometheus
+#  namespace: {{ $.Release.Namespace }}
+#  labels:
+#    app: {{ template "prometheus-operator.name" . }}-prometheus
+#{{- if .Values.global.rbac.pspAnnotations }}
+#  annotations:
+#{{ toYaml .Values.global.rbac.pspAnnotations | indent 4 }}
+#{{- end }}
+#{{ include "prometheus-operator.labels" . | indent 4 }}
+#spec:
+#  privileged: false
+#  # Required to prevent escalations to root.
+#  # allowPrivilegeEscalation: false
+#  # This is redundant with non-root + disallow privilege escalation,
+#  # but we can provide it for defense in depth.
+#  #requiredDropCapabilities:
+#  #  - ALL
+#  # Allow core volume types.
+#  volumes:
+#    - 'configMap'
+#    - 'emptyDir'
+#    - 'projected'
+#    - 'secret'
+#    - 'downwardAPI'
+#    - 'persistentVolumeClaim'
+#  hostNetwork: false
+#  hostIPC: false
+#  hostPID: false
+#  runAsUser:
+#    # Permits the container to run with root privileges as well.
+#    rule: 'RunAsAny'
+#  seLinux:
+#    # This policy assumes the nodes are using AppArmor rather than SELinux.
+#    rule: 'RunAsAny'
+#  supplementalGroups:
+#    rule: 'MustRunAs'
+#    ranges:
+#      # Forbid adding the root group.
+#      - min: 0
+#        max: 65535
+#  fsGroup:
+#    rule: 'MustRunAs'
+#    ranges:
+#      # Forbid adding the root group.
+#      - min: 0
+#        max: 65535
+#  readOnlyRootFilesystem: false
+#{{- if .Values.prometheus.podSecurityPolicy.allowedCapabilities }}
+#  allowedCapabilities:
+#{{ toYaml .Values.prometheus.podSecurityPolicy.allowedCapabilities | indent 4 }}
+#{{- end }}
+#{{- end }}


### PR DESCRIPTION
commenting all the lines since

PodSecurityPolicy in the policy/v1beta1 API version is no longer served as of v1.25, and the PodSecurityPolicy admission controller will be removed.
 